### PR TITLE
Add `CleanWebpackPlugin` to webpack config, so the `build` directory is cleared

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@ckeditor/ckeditor5-theme-lark": "^1.0.0-alpha.2",
     "@ckeditor/ckeditor5-upload": "^1.0.0-alpha.2",
     "babel-minify-webpack-plugin": "^0.2.0",
+	"clean-webpack-plugin": "^0.1.17",
     "postcss-loader": "^2.0.8",
     "raw-loader": "^0.5.1",
     "style-loader": "^0.18.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,11 +9,14 @@
 
 const path = require( 'path' );
 const webpack = require( 'webpack' );
+const CleanWebpackPlugin = require( 'clean-webpack-plugin' );
 const { bundler } = require( '@ckeditor/ckeditor5-dev-utils' );
 const { getPostCssConfig } = require( '@ckeditor/ckeditor5-dev-utils' ).styles;
 const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' );
 const BabiliPlugin = require( 'babel-minify-webpack-plugin' );
 const buildConfig = require( './build-config' );
+
+const OUTPUT_DIRECTORY = path.resolve( __dirname, 'build' );
 
 module.exports = {
 	devtool: 'source-map',
@@ -21,7 +24,7 @@ module.exports = {
 	entry: path.resolve( __dirname, 'src', 'ckeditor.js' ),
 
 	output: {
-		path: path.resolve( __dirname, 'build' ),
+		path: OUTPUT_DIRECTORY,
 		filename: 'ckeditor.js',
 		libraryTarget: 'umd',
 		libraryExport: 'default',
@@ -29,6 +32,7 @@ module.exports = {
 	},
 
 	plugins: [
+		new CleanWebpackPlugin( [ OUTPUT_DIRECTORY ] ),
 		new CKEditorWebpackPlugin( {
 			language: buildConfig.config.language,
 			additionalLanguages: 'all'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Added `CleanWebpackPlugin` to webpack config, so the `build` directory is cleared after each build. Part of ckeditor/ckeditor5#700.